### PR TITLE
feat: make batch ingestion async (#54)

### DIFF
--- a/internal/ingest/httpingest/httpingest_test.go
+++ b/internal/ingest/httpingest/httpingest_test.go
@@ -96,13 +96,33 @@ func TestBatchHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	require.Len(t, collector.events, 10)
-
 	lastRecivedEvent := collector.events[len(collector.events)-1]
 	comperableEvent := collector.events[len(collector.events)-2]
-
-	assert.Equal(t, "id10", lastRecivedEvent.ID())
-	assert.Equal(t, "sub10", lastRecivedEvent.Subject())
-	assert.Equal(t, "test10", lastRecivedEvent.Source())
 	assert.NotEqual(t, comperableEvent.Time(), lastRecivedEvent.Time())
+
+	assert.True(t, slicesAreEqual(events, collector.events))
+}
+
+func slicesAreEqual(slice1, slice2 []event.Event) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+
+	counts := make(map[string]int)
+
+	for _, element := range slice1 {
+		counts[element.ID()]++
+	}
+
+	for _, element := range slice2 {
+		counts[element.ID()]--
+	}
+
+	for _, count := range counts {
+		if count != 0 {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Hi! 

Hope you don't mind. I tried to implement the async batch processing request.

Please feel free to review my changes and request additional. Thank you!

## Overview

- Refactored batch ingestion to async via WaitGroup
- Used channels to gather all errors

Fixes #54 PR comment bellow
https://github.com/openmeterio/openmeter/pull/96#discussion_r1258572153

## Notes for reviewer

Created error array in order to return all errors which occurred during batch. (Returned IDs in local testing)

`2023/07/13 22:34:55 ERROR unable to process request error="id10\nid1\nid2\nid3\nid4\nid5\nid6\nid7\nid8\nid9"` 